### PR TITLE
Add CODEOWNERS file

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,0 +1,2 @@
+* @michplunkett
+*.js @michplunkett @Asteinhart @GreenbackCafe @vernonli1 @Aufsteyegen @tiffanyl9 @ne0npink @JRamosRuballos


### PR DESCRIPTION
## What does this PR do?
Adds a `CODEOWNERS` file so that people are added to the review list based on what type of files are modified.

## How was the functionality tested and verified?
- [x] GitHub certifies that the file is in the correct format.

<img width="288" alt="Screenshot 2023-10-29 at 5 13 15 PM" src="https://github.com/chicagomaroon/data-visualizations/assets/5885605/3c503ffb-c852-46d2-b073-69bad5050d70">